### PR TITLE
Fix comment issue (?) in COMMAND

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ CMD gpg --keyserver keys.gnupg.net --recv-keys 6AD860EED4598027 && \
     rm -rf zfs-utils && \
     git clone https://aur.archlinux.org/zfs-utils.git && \
     pushd zfs-utils && \
-    # makepkg --install --syncdeps --clean --rmdeps --noconfirm && \
-    makepkg --syncdeps --clean --rmdeps --noconfirm && \
+    makepkg --install --syncdeps --clean --rmdeps --noconfirm && \
+    # makepkg --syncdeps --clean --rmdeps --noconfirm && \
     popd && \
     rm -rf zfs-linux-lts && \
     git clone https://aur.archlinux.org/zfs-linux-lts.git && \


### PR DESCRIPTION
In my environment, preventing installation of zfs-utils in the container resulted in later error compiling zfs-linux-lts due to missing dependency. Enabiling install (i.e. moving comment in the next line) avoided this error.  I don't know if this comment is intended, could you please review?